### PR TITLE
support windows backslash

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 
 import { resolveGlobalLayout } from './resolver';
 import { generateRoutesCode } from './template';
@@ -21,6 +22,9 @@ function stripExt(p: string) {
 }
 
 export function transformToRelativePath(to: string, from: string) {
+  if(os.platform()==='win32'){
+    return './' + stripExt(path.relative(path.dirname(path.resolve(from)), to)).replace(/\\/g, '/')
+  }
   return './' + stripExt(path.relative(path.dirname(path.resolve(from)), to));
 }
 

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import os from  'os';
 import { resolveOptions, resolvePages, resolveRoutes, scan } from './resolver';
 import { ResolvedOptions } from './types';
 
@@ -15,7 +16,7 @@ test('resolver:resolveOptions', () => {
     async: true,
     extensions: ['tsx', 'ts', 'jsx', 'js'],
     pageDir,
-    root: process.cwd(),
+    root: os.platform()!=='win32'? process.cwd():process.cwd().replace(/\\/g, '/'),
     output: path.join(process.cwd(), 'src', 'routes.tsx'),
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import consola from 'consola';
+import os from 'os';
 import { upperFirst, camelCase } from 'lodash';
 
 import { name } from '../package.json';
@@ -49,14 +50,25 @@ export function normalizeDirPathToRoute(dirPath: string) {
     .join('/');
 }
 
+function stripTrailingSlash(str: string) {
+  const asdf = str.substring(str.length - 1);
+  if (str.substring(str.length - 1) === '/' && str !== '/' && str !== './') {
+    return str.substring(0, str.length - 1);
+  }
+  return str;
+}
+
 export function normalizePathToRoute(p: string) {
   const { dir, name } = path.parse(p);
   const route = normalizeFilenameToRoute(name);
   if (route === MATCH_ALL_ROUTE) {
     return route;
   }
-
-  return path.resolve(path.join('/', normalizeDirPathToRoute(dir), route));
+  return os.platform() === 'win32'
+    ? stripTrailingSlash(
+        path.join('/', normalizeDirPathToRoute(dir), route).replace(/\\/g, '/')
+      )
+    : path.resolve(path.join('/', normalizeDirPathToRoute(dir), route));
 }
 
 export function countLength(p: string) {
@@ -78,7 +90,7 @@ export function sortRoutes(routes: string[]) {
 }
 
 export function getComponentName(filePath: string) {
-  const segments = filePath.split(path.sep);
+  const segments = filePath.split(/[\\\/]/);
   const extname = path.extname(filePath);
   const fileName = path.basename(filePath, extname);
 


### PR DESCRIPTION
overall
convert "\\" to "/" 

utils.ts
normalizePathToRoute
make function return "/" instead of "C:\\..."

getComponentName
make function to parse // and \

resolved: #1 
