### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pnpm add vite-plugin-next-react-router -D
 Add plugin to your `vite.config.js`
 
 ```js
-import { reactRouterPlugin } from 'vite-plugin-next-react-router';
+import reactRouterPlugin from 'vite-plugin-next-react-router';
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
`reactRouterPlugin` is exported as default and documentation about it is outdated. Trying to destructure this import will cause error.

The error:

```bash
failed to load config from /projects/react-vite-tailwind/vite.config.ts
error when starting dev server:
file:///projects/react-vite-tailwind/vite.config.ts.timestamp-1682832385216.mjs:3
import { reactRouterPlugin } from "vite-plugin-next-react-router";
         ^^^^^^^^^^^^^^^^^
SyntaxError: The requested module 'vite-plugin-next-react-router' does not provide an export named 'reactRouterPlugin'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:123:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:189:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:530:24)
    at async loadConfigFromBundledFile (file:///projects/react-vite-tailwind/node_modules/vite/dist/node/chunks/dep-88cc3a4f.js:63033:21)
    at async loadConfigFromFile (file:///projects/react-vite-tailwind/node_modules/vite/dist/node/chunks/dep-88cc3a4f.js:62919:28)
    at async resolveConfig (file:///projects/react-vite-tailwind/node_modules/vite/dist/node/chunks/dep-88cc3a4f.js:62533:28)
    at async createServer (file:///projects/react-vite-tailwind/node_modules/vite/dist/node/chunks/dep-88cc3a4f.js:59133:20)
    at async CAC.<anonymous> (file:///projects/react-vite-tailwind/node_modules/vite/dist/node/cli.js:699:24)
```